### PR TITLE
PageInner & Select

### DIFF
--- a/src/components/common/atoms/BasicStyles.tsx
+++ b/src/components/common/atoms/BasicStyles.tsx
@@ -11,6 +11,12 @@ export const InnerBox = styled.div`
   min-width: 320px;
 `;
 
+/** \# 최대 넓이 1200px, 최소 넓이 320px인 가로 가운데 정렬된 공간 / 헤더 및 푸터에 따라 높이 조정 */
+export const PageInnerBox = styled(InnerBox)`
+  padding: ${({ theme }) => theme.size.lg};
+  min-height: calc(100vh - 17rem);
+`;
+
 /**
  * \# Flex-box
  * @param justifyContent ? `"center"(def) | "flex-start" | "flex-end" | "space-between" | "space-around";`

--- a/src/components/common/atoms/Select.d.ts
+++ b/src/components/common/atoms/Select.d.ts
@@ -1,0 +1,8 @@
+import { IUseSelectResult } from "../../../hooks/useSelect.d";
+
+/** \# Select 타입 */
+export interface ISelect {
+  width: string;
+  list: string[];
+  select: IUseSelectResult;
+}

--- a/src/components/common/atoms/Select.tsx
+++ b/src/components/common/atoms/Select.tsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+
+import { ISelect } from "./Select.d";
+
+//# select 스타일
+const SelectStyle = styled.select<Pick<ISelect, "width">>`
+  width: ${({ width }) => width};
+  padding: ${({ theme }) => theme.size.sm};
+  padding-right: ${({ theme }) => theme.size.lg};
+  border-radius: ${({ theme }) => theme.size.br};
+  background-color: transparent; //> ArrowStyle 보임
+  color: ${({ theme }) => theme.colors.text};
+  cursor: pointer;
+`;
+
+//# select 화살표 스타일
+const ArrowStyle = styled.span`
+  position: absolute;
+  transform: translate(-2rem, 0.6rem);
+  z-index: -1; //> SelectStyle 클릭 가능
+`;
+
+/**
+ * \# Select & Option
+ * @param width `string` select 넓이
+ * @param list `string[]` option 목록
+ * @param select `{ attribute, value, setValue }` useSelect의 반환값
+ */
+export function Select(props: ISelect) {
+  return (
+    <div>
+      <SelectStyle width={props.width} {...props.select.attribute}>
+        {props.list.map((el) => (
+          <option key={el}>{el}</option>
+        ))}
+      </SelectStyle>
+      <ArrowStyle>▼</ArrowStyle>
+    </div>
+  );
+}

--- a/src/components/create/Create.tsx
+++ b/src/components/create/Create.tsx
@@ -1,0 +1,14 @@
+import { useSelect } from "../../hooks/useSelect";
+import { PageInnerBox } from "../common/atoms/BasicStyles";
+import { Select } from "../common/atoms/Select";
+
+export function Create() {
+  const EXAMPLES = ["1번 목록입니다.", "2번 목록입니다.", "3번 목록입니다."]; //!
+  const select = useSelect(EXAMPLES[0]);
+
+  return (
+    <PageInnerBox>
+      <Select width="14rem" list={EXAMPLES} select={select} />
+    </PageInnerBox>
+  );
+}

--- a/src/hooks/useSelect.d.ts
+++ b/src/hooks/useSelect.d.ts
@@ -1,0 +1,10 @@
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
+
+export interface IUseSelectResult {
+  attribute: {
+    value: string;
+    onChange: (ev: ChangeEvent<HTMLSelectElement>) => void;
+  };
+  value: string;
+  setValue: Dispatch<SetStateAction<string>>;
+}

--- a/src/hooks/useSelect.ts
+++ b/src/hooks/useSelect.ts
@@ -1,0 +1,32 @@
+import { ChangeEvent, useState } from "react";
+
+import { IUseSelectResult } from "./useSelect.d";
+
+/**
+ * \# select 요소 값 관리
+ *
+ * e.g.
+ *
+ * const exampleSelect = useSelect(EXAMPLES[0])
+ *
+ * \<select {...exampleSelect.attribute}>
+ *
+ * {EXAMPLES.map((ex) => (<option key={ex}>{ex}</option>))}
+ *
+ * </ select>
+ * @param initialValue 초깃값
+ * @returns \{ `attribute`: select 요소의 속성, `value`: 선택된 값, `setValue`: 값 직접 변경 시 사용 }
+ */
+export const useSelect = (initialValue: string): IUseSelectResult => {
+  const [value, setValue] = useState(initialValue);
+
+  const onChange = (ev: ChangeEvent<HTMLSelectElement>) => {
+    if (ev.target.value !== value) setValue(ev.target.value);
+  };
+
+  return {
+    attribute: { value, onChange },
+    value,
+    setValue,
+  };
+};

--- a/src/pages/create/index.tsx
+++ b/src/pages/create/index.tsx
@@ -1,0 +1,5 @@
+import { Create } from "../../components/create/Create";
+
+export default function CreatePage() {
+  return <Create />;
+}

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -11,7 +11,18 @@ const GlobalStyle = createGlobalStyle`
   html {
     font-size: 62.5%; //> 1rem = 10px;  
   }
-  
+
+  //^IE
+  select::-ms-expand {
+    display: none;
+  }
+  //# SELECT 기본 스타일 제거
+  select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
+    
   ${({ theme }) => {
     return css`
       body {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -4,6 +4,7 @@ export const size = {
   md: "1rem",
   lg: "2rem",
   xl: "3rem",
+  br: "5px",
 };
 
 //# 폰트


### PR DESCRIPTION
- PageInner 스타일 추가
  - 브라우저의 높이에서 헤더와 푸터의 높이를 빼서 푸터 아래의 공간이 보이는 것을 막음

<img width="800" alt="페이지 이너" src="https://user-images.githubusercontent.com/84524514/187863869-a11eb35d-9b1c-4bf1-962e-4be5604ab9e6.png">

- Select 컴포넌트 추가
  - useSelect 추가
  - select 기본 스타일 제거

기존 select
<img width="450" alt="select 기존" src="https://user-images.githubusercontent.com/84524514/187881064-5d9e9dec-cb77-4b34-8511-269531809a9f.png">

스타일 적용 select
<img width="450" alt="select 수정" src="https://user-images.githubusercontent.com/84524514/187881417-17c8b858-95b6-4872-8a6d-77a4771d8189.png">

\*좌측 Safari, 우측 Chrome