### PR TITLE
시험 생성 페이지에 탭 추가

### DIFF
--- a/src/components/atoms/BasicStyles.tsx
+++ b/src/components/atoms/BasicStyles.tsx
@@ -43,3 +43,10 @@ export const Btn = styled.div`
   -ms-user-select: none;
   user-select: none;
 `;
+
+/** \# 강조색을 테두리로 가지는 공간 */
+export const BorderDiv = styled.div`
+  padding: ${({ theme }) => theme.size.lg};
+  border: 1px solid ${({ theme }) => theme.colors.accent};
+  width: 100%;
+`;

--- a/src/components/atoms/Btns.tsx
+++ b/src/components/atoms/Btns.tsx
@@ -51,3 +51,23 @@ export const CancelBtn = styled(BorderBtn)`
   background-color: ${({ theme }) => theme.colors.primary};
   color: ${({ theme }) => theme.colors.accent};
 `;
+
+/**
+ * \# 탭 버튼
+ * @param width  버튼 넓이
+ * @param isActive 탭 활성화 여부
+ */
+export const TapBtn = styled(Btn)<{ width: string; isActive: boolean }>`
+  width: ${({ width }) => width};
+  padding: ${({ theme }) => theme.size.sm};
+  padding-top: ${({ theme }) => theme.size.md};
+  border-radius: ${({ theme }) => theme.size.br} ${({ theme }) => theme.size.br}
+    0 0;
+  background-color: ${({ theme, isActive }) =>
+    isActive ? theme.colors.accent : "transparent"};
+  text-align: center;
+  &:hover {
+    color: ${({ theme, isActive }) =>
+      isActive ? theme.colors.primary : theme.colors.accent};
+  }
+`;

--- a/src/components/create/Create.tsx
+++ b/src/components/create/Create.tsx
@@ -1,15 +1,35 @@
-import { useSelect } from "../../hooks/useSelect";
-import { PageInnerBox } from "../atoms/BasicStyles";
-import { Select } from "../atoms/Select";
+import { useState } from "react";
+
+import { BorderDiv, FlexBox, PageInnerBox } from "../atoms/BasicStyles";
+import { TapBtn } from "../atoms/Btns";
 
 /** \# 시험 생성 페이지 */
 export function Create() {
-  const EXAMPLES = ["1번 목록입니다.", "2번 목록입니다.", "3번 목록입니다."]; //!
-  const select = useSelect(EXAMPLES[0]);
+  //#
+  const [isTestInfoActive, setIsTestInfoActive] = useState<boolean>(true);
+  const toggleActive = () => {
+    setIsTestInfoActive((prevState) => !prevState);
+  };
 
   return (
     <PageInnerBox>
-      <Select width="14rem" list={EXAMPLES} select={select} />
+      <FlexBox justifyContent="flex-start">
+        <TapBtn
+          onClick={toggleActive}
+          width="10rem"
+          isActive={isTestInfoActive}
+        >
+          1. 시험 정보
+        </TapBtn>
+        <TapBtn
+          onClick={toggleActive}
+          width="10rem"
+          isActive={!isTestInfoActive}
+        >
+          2. 문제
+        </TapBtn>
+      </FlexBox>
+      <BorderDiv>{isTestInfoActive ? "시험 정보" : "문제"}</BorderDiv>
     </PageInnerBox>
   );
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -42,18 +42,18 @@ export const device = {
 };
 
 //# 색상
-const colors = {
-  accent: "#7F00FF",
-};
+const colors = {};
 
 export const lightThemeColors = {
   ...colors,
+  accent: "#C8A2C8",
   text: "#222120",
   primary: "#FAFAFA",
 };
 
 const darkThemeColors = {
   ...colors,
+  accent: "#7F00FF",
   text: "#FAFAFA",
   primary: "#222120",
 };


### PR DESCRIPTION
- 테마별 강조색 구분

  <img width="180" alt="색상" src="https://user-images.githubusercontent.com/84524514/187982260-388eb5d8-c2e4-4539-b00a-34e4acdf9258.png">

- 시험 생성 페이지에 탭 추가
  - BorderDiv 추가
  - TabBtn 추가
  
  ![탭](https://user-images.githubusercontent.com/84524514/187982102-fdab48c5-6de4-47be-8689-593c03f56120.gif)